### PR TITLE
Make the code a bit more idiomatic.

### DIFF
--- a/configure/certificates.go
+++ b/configure/certificates.go
@@ -46,8 +46,8 @@ func generateRootCA(path string) {
 	}
 
 	notBefore := time.Now()
-
-	notAfter := notBefore.Add(10000000000000000)
+	// Certificate validity set to one year.
+	notAfter := notBefore.AddDate(1, 0, 0)
 
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -91,7 +91,7 @@ func TestAddTracersQueryTags(t *testing.T) {
 	numTracers, err := testAddTracerQueryHelper(requestDataTags)
 	if err != nil {
 		t.Fatalf("Failed to insert Tracers with error: %+v", err)
-	} else if numTracers != 1 { //1 is the number of exspected tracers
+	} else if numTracers != 1 { //1 is the number of expected tracers
 		t.Fatalf("Failed to find all Tracers %d", numTracers)
 	}
 }


### PR DESCRIPTION
proxy/cert.go:generateCert did not return error as the last return
value. This has been modified, as a result calling it in the certCache
has also been modified.

time.AddDate(years int, months int, days int) is easier to use than
just time.Add(10000000000000000000000000000000). The validity of certs
has been set to 1 year in both proxy/cert.go:generateCert and
configure/certificates.go:generateRootCA.

The anonymous function in proxy/cert.go:certCache now has a short
statement instead of a statement and an if.

We can go through https://github.com/golang/go/wiki/CodeReviewComments
and make a lot more changes (e.g. adding godoc comments to functions or 
returning errors in configure/certificates.go functions).

Above all, thanks for contributing to Go's infosec community.