### PR TITLE
Changed package location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ COMMIT=$(shell git rev-parse HEAD)
 BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 
 # Symlink into GOPATH
-PROJECT_NAME=tracy
+PROJECT_NAME=github.com/nccgroup/tracy
 BUILD_DIR=${GOPATH}/src/${PROJECT_NAME}
 CURRENT_DIR=$(shell pwd)
 BUILD_DIR_LINK=$(shell readlink ${BUILD_DIR})

--- a/api/common/configure.go
+++ b/api/common/configure.go
@@ -2,7 +2,7 @@ package common
 
 import (
 	"encoding/json"
-	"tracy/configure"
+	"github.com/nccgroup/tracy/configure"
 )
 
 /*GetConfig is the common functionality for getting the global configuration. */

--- a/api/common/event.go
+++ b/api/common/event.go
@@ -2,10 +2,10 @@ package common
 
 import (
 	"encoding/json"
+	"github.com/nccgroup/tracy/api/store"
+	"github.com/nccgroup/tracy/api/types"
+	"github.com/nccgroup/tracy/log"
 	"strings"
-	"tracy/api/store"
-	"tracy/api/types"
-	"tracy/log"
 
 	"github.com/yosssi/gohtml"
 	"golang.org/x/net/html"

--- a/api/common/tracer.go
+++ b/api/common/tracer.go
@@ -2,10 +2,10 @@ package common
 
 import (
 	"encoding/json"
+	"github.com/nccgroup/tracy/api/store"
+	"github.com/nccgroup/tracy/api/types"
+	"github.com/nccgroup/tracy/log"
 	"strings"
-	"tracy/api/store"
-	"tracy/api/types"
-	"tracy/log"
 )
 
 /*AddTracer is the common functionality to add a tracer to the database. This function

--- a/api/common/websocket.go
+++ b/api/common/websocket.go
@@ -2,10 +2,10 @@ package common
 
 import (
 	"github.com/gorilla/websocket"
+	"github.com/nccgroup/tracy/api/types"
+	"github.com/nccgroup/tracy/log"
 	"math/rand"
 	"time"
-	"tracy/api/types"
-	"tracy/log"
 )
 
 var subscribers map[int]*subscriber

--- a/api/rest/config_server_helper_test.go
+++ b/api/rest/config_server_helper_test.go
@@ -1,12 +1,12 @@
 package rest
 
 import (
+	"github.com/nccgroup/tracy/api/store"
+	"github.com/nccgroup/tracy/configure"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
-	"tracy/api/store"
-	"tracy/configure"
 )
 
 /* A function that takes a slice of RequestTestPairs. Each pair has a request and a

--- a/api/rest/configure_rest.go
+++ b/api/rest/configure_rest.go
@@ -1,8 +1,8 @@
 package rest
 
 import (
+	"github.com/nccgroup/tracy/api/common"
 	"net/http"
-	"tracy/api/common"
 )
 
 /*GetConfig gets the global configuration for the application. */

--- a/api/rest/event_rest.go
+++ b/api/rest/event_rest.go
@@ -3,13 +3,13 @@ package rest
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/nccgroup/tracy/api/common"
+	"github.com/nccgroup/tracy/api/store"
+	"github.com/nccgroup/tracy/api/types"
+	"github.com/nccgroup/tracy/log"
 	"net/http"
 	"strconv"
 	"strings"
-	"tracy/api/common"
-	"tracy/api/store"
-	"tracy/api/types"
-	"tracy/log"
 
 	"github.com/gorilla/mux"
 )

--- a/api/rest/event_rest_test.go
+++ b/api/rest/event_rest_test.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/nccgroup/tracy/api/types"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"tracy/api/types"
 )
 
 /* Testing adding a tracer event. POST /tracers/<tracer_id>/events */

--- a/api/rest/init_rest.go
+++ b/api/rest/init_rest.go
@@ -6,13 +6,13 @@ import (
 	"flag"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
+	"github.com/nccgroup/tracy/configure"
+	"github.com/nccgroup/tracy/log"
 	l "log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"time"
-	"tracy/configure"
-	"tracy/log"
 )
 
 /*RestServer is the HTTP server that serves all the API. */

--- a/api/rest/rest_server_helper_test.go
+++ b/api/rest/rest_server_helper_test.go
@@ -1,12 +1,12 @@
 package rest
 
 import (
+	"github.com/nccgroup/tracy/api/store"
+	"github.com/nccgroup/tracy/configure"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
-	"tracy/api/store"
-	"tracy/configure"
 )
 
 /* A function that takes a slice of RequestTestPairs. Each pair has a request and a

--- a/api/rest/tracer_rest.go
+++ b/api/rest/tracer_rest.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 
 	"github.com/gorilla/mux"
+	"github.com/nccgroup/tracy/api/common"
+	"github.com/nccgroup/tracy/api/types"
+	"github.com/nccgroup/tracy/log"
+	"github.com/nccgroup/tracy/proxy"
 	"net/http"
 	"strconv"
-	"tracy/api/common"
-	"tracy/api/types"
-	"tracy/log"
-	"tracy/proxy"
 )
 
 /*AddTracers decodes an HTTP request to add a new tracer(s) to the database. */

--- a/api/rest/tracer_rest_test.go
+++ b/api/rest/tracer_rest_test.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/nccgroup/tracy/api/types"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"tracy/api/types"
 )
 
 /* Testing addTracer with httptest. POST /tracers */

--- a/api/rest/websocket.go
+++ b/api/rest/websocket.go
@@ -2,9 +2,9 @@ package rest
 
 import (
 	"github.com/gorilla/websocket"
+	"github.com/nccgroup/tracy/api/common"
+	"github.com/nccgroup/tracy/log"
 	"net/http"
-	"tracy/api/common"
-	"tracy/log"
 )
 
 var upgrader = websocket.Upgrader{

--- a/api/store/sqlite.go
+++ b/api/store/sqlite.go
@@ -1,8 +1,8 @@
 package store
 
 import (
-	"tracy/api/types"
-	"tracy/log"
+	"github.com/nccgroup/tracy/api/types"
+	"github.com/nccgroup/tracy/log"
 
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"

--- a/configure/certificates.go
+++ b/configure/certificates.go
@@ -8,13 +8,13 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"github.com/nccgroup/tracy/log"
 	l "log"
 	"math/big"
 	"net"
 	"os"
 	"path/filepath"
 	"time"
-	"tracy/log"
 )
 
 var SigningCertificate tls.Certificate

--- a/configure/configure.go
+++ b/configure/configure.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"github.com/nccgroup/tracy/log"
 	"io/ioutil"
 	l "log"
 	"net"
@@ -11,7 +12,6 @@ import (
 	"os/user"
 	"path/filepath"
 	"strings"
-	"tracy/log"
 )
 
 /*TracyPath is the path all tracy files go in. */

--- a/main.go
+++ b/main.go
@@ -6,6 +6,11 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
+	"github.com/nccgroup/tracy/api/rest"
+	"github.com/nccgroup/tracy/api/store"
+	"github.com/nccgroup/tracy/configure"
+	"github.com/nccgroup/tracy/log"
+	"github.com/nccgroup/tracy/proxy"
 	"io/ioutil"
 	_ "net/http/pprof"
 	"os"
@@ -14,11 +19,6 @@ import (
 	"runtime"
 	"runtime/pprof"
 	"strings"
-	"tracy/api/rest"
-	"tracy/api/store"
-	"tracy/configure"
-	"tracy/log"
-	"tracy/proxy"
 )
 
 var cpuprofile = flag.String("cpuprofile", "", "write cpu profile to file")

--- a/proxy/cert.go
+++ b/proxy/cert.go
@@ -10,6 +10,8 @@ import (
 	"crypto/x509/pkix"
 	"encoding/json"
 	"encoding/pem"
+	"github.com/nccgroup/tracy/configure"
+	"github.com/nccgroup/tracy/log"
 	"io/ioutil"
 	"math/big"
 	"net"
@@ -17,8 +19,6 @@ import (
 	"os"
 	"strings"
 	"time"
-	"tracy/configure"
-	"tracy/log"
 )
 
 /* Upgrade a TLS connection if the proxy receives a 'CONNECT' action from the connection. */

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -6,17 +6,17 @@ import (
 	"compress/gzip"
 	"crypto/tls"
 	"encoding/json"
+	"github.com/nccgroup/tracy/api/common"
+	"github.com/nccgroup/tracy/api/store"
+	"github.com/nccgroup/tracy/api/types"
+	"github.com/nccgroup/tracy/configure"
+	"github.com/nccgroup/tracy/log"
 	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httputil"
 	"strings"
-	"tracy/api/common"
-	"tracy/api/store"
-	"tracy/api/types"
-	"tracy/configure"
-	"tracy/log"
 )
 
 /*ListenAndServe waits and listens for TCP connections and proxies them. */

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -4,11 +4,11 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"github.com/nccgroup/tracy/api/types"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-	"tracy/api/types"
 )
 
 var requestDataNoTags = `GET /api/v1/action/ HTTP/1.1

--- a/proxy/tracer.go
+++ b/proxy/tracer.go
@@ -3,15 +3,15 @@ package proxy
 import (
 	"bytes"
 	"fmt"
+	"github.com/nccgroup/tracy/api/types"
+	"github.com/nccgroup/tracy/configure"
+	"github.com/nccgroup/tracy/log"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
-	"tracy/api/types"
-	"tracy/configure"
-	"tracy/log"
 )
 
 /* Helper function for searching for tracer tags in query parameters and body and replacing them with randomly generated


### PR DESCRIPTION
Please would it be possible to change the package naming to match normal Go conventions, as done by this PR?

Currently this tool assumes that it is in "$GOPATH/src/tracy", whereas normally it would be in "$GOPATH/src/github.com/nccgroup/tracy".