### PR TITLE
Add proxy test and benchmark

### DIFF
--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -196,7 +196,7 @@ func testFindTracersHelper(responseData string, tracers []types.Request) (int, e
 func TestFullProxy(t *testing.T) {
 	// Test just sending data, no trace strings
 	body, err := makeRequest(ts.URL, "a")
-	if err != nil && bytes.Compare(body, []byte("<div>a</div>")) != 0 {
+	if err != nil || bytes.Compare(body, []byte("<div>a</div>\n")) != 0 {
 		log.Error.Println(err)
 		t.FailNow()
 	}


### PR DESCRIPTION
My implementation for https://github.com/nccgroup/tracy/issues/31 , need the ability to benchmark so I can follow up with memory optimizations. pinging @jacobheath 

```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ github.com/nccgroup/tracy/proxy -bench ^BenchmarkFullProxy$

goos: darwin
goarch: amd64
pkg: github.com/nccgroup/tracy/proxy
BenchmarkFullProxy-4   	    2000	    719697 ns/op	  331515 B/op	    2942 allocs/op
PASS
ok  	github.com/nccgroup/tracy/proxy	1.581s
Success: Benchmarks passed.
```

```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ github.com/nccgroup/tracy/proxy -bench ^BenchmarkFullProxy$

goos: darwin
goarch: amd64
pkg: github.com/nccgroup/tracy/proxy
BenchmarkFullProxy-4   	    2000	   1200910 ns/op	  432044 B/op	    4771 allocs/op
PASS
ok  	github.com/nccgroup/tracy/proxy	2.562s
Success: Benchmarks passed.
```

seems like a fair amount of variance, this might be network related.