### PR TITLE
This merge will introduce reproduction behavior for sev level 3 and 2

### DIFF
--- a/api/common/project.go
+++ b/api/common/project.go
@@ -49,10 +49,5 @@ func DeleteProject(p string) error {
 func SwitchProject(p string) error {
 	store.DB.Close()
 	configure.DatabaseFile = filepath.Join(configure.TracyPath, p+".db")
-
-	if err := store.Open(configure.DatabaseFile, log.Verbose); err != nil {
-		return err
-	}
-
-	return nil
+	return store.Open(configure.DatabaseFile, log.Verbose)
 }

--- a/api/common/repro.go
+++ b/api/common/repro.go
@@ -1,0 +1,198 @@
+package common
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/nccgroup/tracy/api/store"
+	"github.com/nccgroup/tracy/api/types"
+	"github.com/nccgroup/tracy/log"
+)
+
+// StartReproductions makes the raw HTTP request that initatied the
+// tracer, then sends off the event to the extension via websocket
+// to be completed by the extension.
+func StartReproductions(tracerID, contextID uint) {
+	// Get the tracer associated with this event.
+	var tracer types.Tracer
+	if err := store.DB.First(&tracer, tracerID).Error; err != nil {
+		log.Error.Print(err)
+		return
+	}
+
+	// Get the raw request associated with this tracer.
+	var req types.Request
+	if err := store.DB.First(&req, tracer.RequestID).Error; err != nil {
+		log.Error.Print(err)
+		return
+	}
+
+	// Get the DOMContext associated with the event.
+	var context types.DOMContext
+	if err := store.DB.First(&context, contextID).Error; err != nil {
+		log.Error.Print(err)
+		return
+	}
+
+	// Get the event associated with the DOM context.
+	var event types.TracerEvent
+	if err := store.DB.First(&event, context.TracerEventID).Error; err != nil {
+		log.Error.Print(err)
+		return
+	}
+
+	// This is the state machine that picks the appropriate
+	// payloads to make sure our reproduction executes properly based
+	// on where in the DOM we found the input.
+	exploits := exploitStateMachine(context)
+	rts := make([]types.ReproductionTest, len(exploits))
+	for i, exploit := range exploits {
+		rt := types.ReproductionTest{
+			TracerEventID: event.ID,
+			Exploit:       exploit,
+			Successful:    false, // all tests default to false
+		}
+		go createReproductionTest(req, tracer, context, rt)
+		rts[i] = rt
+	}
+
+	UpdateSubscribers(types.Reproduction{
+		Tracer:            tracer,
+		TracerEvent:       event,
+		DOMContext:        context,
+		ReproductionTests: rts,
+	})
+}
+
+// createReproductionTest creates a row in the events
+// reproduction test table, replays the request that generated
+// the event with the exploit, and notifies the extensions
+// to see what happened using a tab.
+func createReproductionTest(req types.Request, tracer types.Tracer, context types.DOMContext, reproTest types.ReproductionTest) {
+	if err := store.DB.Create(&reproTest).Error; err != nil {
+		log.Error.Print(err)
+		return
+	}
+	if err := replayInjectionPoint(req, tracer.TracerPayload, reproTest.Exploit); err != nil {
+		log.Error.Print(err)
+		return
+	}
+}
+
+// UpdateReproduction changes the status of a tracer event to
+// reproduced. This should only happen once the extensions injected
+// script is called from one of its reproduction tabs.
+func UpdateReproduction(tracerID, contextID, reproID uint, repro types.ReproductionTest) error {
+	//TODO: for now, we are just changing the status, but later we might user
+	// these other IDs for doing other types of things.
+	var r types.ReproductionTest
+	if err := store.DB.
+		Model(&r).
+		Where("id = ?", reproID).
+		Update("successful", repro.Successful).
+		Error; err != nil {
+		log.Warning.Print(err)
+		return err
+	}
+	return nil
+}
+
+// exploitStateMachine takes an event and returns a set of payloads
+// that will work for the event context when dropped in place for the
+// tracer payload used to create the event.
+func exploitStateMachine(c types.DOMContext) []string {
+	p := payload()
+	switch c.HTMLLocationType {
+	case types.Attr:
+		return []string{
+			` onload="` + p + `" onfocus="` + p + `" autofocus="" `,
+		}
+	case types.NodeName:
+		return []string{
+			`img src='' onerror="` + p + `"/`,
+		}
+	case types.Text:
+		return []string{
+			`<img src='' onerror="` + p + `"/>`,
+		}
+	case types.AttrVal:
+		// TODO: Can't automatically trigger this. Maybe we can do
+		// something in the future about firing a click event or
+		// something.
+		return []string{
+			`javascript:` + p,
+		}
+	case types.Comment:
+		return []string{
+			`--><img src='' onload="` + p + `" />`,
+		}
+	}
+
+	return []string{}
+}
+
+// payload return the payload the designates XSS was accomplished
+func payload() string {
+	return "window.postMessage({r:1}, `*`)"
+}
+
+// replayInjectionPoint takes a tracer's raw HTTP request
+// and replays it with a given exploit instead of the tracer
+// string that was used originally.
+func replayInjectionPoint(req types.Request, tracerPayload, exploit string) error {
+	u, err := url.Parse(req.RequestURL)
+	if err != nil {
+		log.Warning.Print(err)
+		return err
+	}
+
+	rr := strings.Replace(req.RawRequest, tracerPayload, url.QueryEscape(exploit), -1)
+	// dial require a port. If they used regular 80 and 443, they
+	// won't be included in the URL
+	hosts := strings.Split(u.Host, ":")
+	host := u.Host
+	var conn net.Conn
+	if u.Scheme != "https" {
+		if len(hosts) == 1 {
+			host += ":80"
+		}
+		conn, err := net.Dial("tcp", host)
+		if conn != nil {
+			defer conn.Close()
+		}
+
+		if err != nil {
+			log.Warning.Print(err)
+			return err
+		}
+
+	} else {
+
+		if len(hosts) == 1 {
+			host += ":443"
+		}
+		tserver, err := tls.Dial("tcp", host, &tls.Config{InsecureSkipVerify: true})
+		// Have to check for nil differently with tls.Dial because it
+		// returns a pointer of a connection instead of a struct.
+		var nilTest *tls.Conn
+		if tserver != nilTest {
+			conn = tserver
+			defer conn.Close()
+		}
+
+		if err == io.EOF {
+			return nil
+		}
+
+		if err != nil {
+			log.Warning.Print(err)
+			return err
+		}
+	}
+	fmt.Fprint(conn, rr)
+	return nil
+}

--- a/api/rest/init.go
+++ b/api/rest/init.go
@@ -35,12 +35,13 @@ func Configure() {
 	RestRouter.Methods("GET").Path("/ws").HandlerFunc(WebSocket)
 	RestRouter.Methods("POST").Path("/tracers/{tracerID}/events").HandlerFunc(AddEvent)
 	RestRouter.Methods("GET").Path("/tracers/{tracerID}/events").HandlerFunc(GetEvents)
+	RestRouter.Methods("POST").Path("/tracers/{tracerID}/events/{contextID}/reproductions").HandlerFunc(StartReproductions)
+	RestRouter.Methods("PUT").Path("/tracers/{tracerID}/events/{contextID}/reproductions/{reproID}").HandlerFunc(UpdateReproduction)
 	RestRouter.Methods("POST").Path("/tracers/events/bulk").HandlerFunc(AddEvents)
 	RestRouter.Methods("GET").Path("/config").HandlerFunc(GetConfig)
 	RestRouter.Methods("PUT").Path("/projects").HandlerFunc(SwitchProject)
 	RestRouter.Methods("DELETE").Path("/projects").HandlerFunc(DeleteProject)
 	RestRouter.Methods("GET").Path("/projects").HandlerFunc(GetProjects)
-
 	// The base application page. Don't use the compiled assets unless
 	// in production.
 	if v := flag.Lookup("test.v"); v != nil || configure.DebugUI {

--- a/api/rest/project.go
+++ b/api/rest/project.go
@@ -25,7 +25,7 @@ func GetProjects(w http.ResponseWriter, r *http.Request) {
 func DeleteProject(w http.ResponseWriter, r *http.Request) {
 	proj := r.URL.Query().Get("proj")
 	if proj == "" {
-		returnError(w, fmt.Errorf("No project query parameter was found."))
+		returnError(w, fmt.Errorf("no project query parameter was found"))
 		return
 	}
 
@@ -44,7 +44,7 @@ func DeleteProject(w http.ResponseWriter, r *http.Request) {
 func SwitchProject(w http.ResponseWriter, r *http.Request) {
 	proj := r.URL.Query().Get("proj")
 	if proj == "" {
-		returnError(w, fmt.Errorf("No project query parameter was found."))
+		returnError(w, fmt.Errorf("no project query parameter was found"))
 		return
 	}
 

--- a/api/rest/repro.go
+++ b/api/rest/repro.go
@@ -1,0 +1,101 @@
+package rest
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+	"github.com/nccgroup/tracy/api/common"
+	"github.com/nccgroup/tracy/api/types"
+)
+
+// StartReproductions handles the HTTP API request for starting a
+// reproduction for a particular tracer and event.
+func StartReproductions(w http.ResponseWriter, r *http.Request) {
+	tracerID, contextID, _, err := parsePathVariables(r)
+	if err != nil {
+		returnError(w, err)
+		return
+	}
+
+	// Nothing here needs to wait for this to complete.
+	go common.StartReproductions(tracerID, contextID)
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte{})
+}
+
+// UpdateReproduction handles the HTTP API request for marking
+// a reproduction test case as successful or not.
+func UpdateReproduction(w http.ResponseWriter, r *http.Request) {
+	var repro types.ReproductionTest
+	if err := json.NewDecoder(r.Body).Decode(&repro); err != nil {
+		returnError(w, err)
+		return
+	}
+
+	tracerID, contextID, vars, err := parsePathVariables(r)
+	if err != nil {
+		returnError(w, err)
+		return
+	}
+
+	reproIDs, ok := vars["reproID"]
+	if !ok {
+		returnError(w, fmt.Errorf("No reproID variable found in the path"))
+		return
+	}
+	var reproID uint64
+	reproID, err = strconv.ParseUint(reproIDs, 10, 32)
+	if err != nil {
+		returnError(w, fmt.Errorf("Not a valid uint for reproID"))
+		return
+	}
+
+	if err = common.UpdateReproduction(tracerID, contextID, uint(reproID), repro); err != nil {
+		returnError(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte{})
+}
+
+// parsePathVariables is a helper function used to parse the path
+// variables for the repro API.
+func parsePathVariables(r *http.Request) (uint, uint, map[string]string, error) {
+	vars := mux.Vars(r)
+	var (
+		ok         bool
+		tracerIDs  string
+		contextIDs string
+	)
+
+	tracerIDs, ok = vars["tracerID"]
+	if !ok {
+		return 0, 0, nil, fmt.Errorf("No tracerID variable found in the path")
+	}
+
+	contextIDs, ok = vars["contextID"]
+	if !ok {
+		return 0, 0, nil, fmt.Errorf("No eventID variable found in the path")
+	}
+
+	var (
+		tracerID  uint64
+		contextID uint64
+		err       error
+	)
+	tracerID, err = strconv.ParseUint(tracerIDs, 10, 32)
+	if err != nil {
+		return 0, 0, nil, fmt.Errorf("Not a valid uint for tracerID")
+	}
+
+	contextID, err = strconv.ParseUint(contextIDs, 10, 32)
+	if err != nil {
+		return 0, 0, nil, fmt.Errorf("Not a valid uint for contextID")
+	}
+
+	return uint(tracerID), uint(contextID), vars, nil
+}

--- a/api/rest/tracer.go
+++ b/api/rest/tracer.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"net/http"
+	"strconv"
+
 	"github.com/gorilla/mux"
 	"github.com/nccgroup/tracy/api/common"
 	"github.com/nccgroup/tracy/api/types"
 	"github.com/nccgroup/tracy/proxy"
-	"net/http"
-	"strconv"
 )
 
 // AddTracers handles the HTTP API request to add a set of tracers from a Request
@@ -95,10 +96,6 @@ func GenerateTracer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	//TODO: should collect more information about the location of where
-	// it was generated. generating a tracer like this loses information
-	// about inputs without being obvious about it. if we wanted to do
-	// reproduction steps, how would we do that here?
 	genTracer := types.Request{
 		RawRequest:    "GENERATED", // For generated tracers, there won't be a request
 		RequestMethod: "GENERATED", // For generated tracers, there won't be a request method

--- a/api/store/sqlite.go
+++ b/api/store/sqlite.go
@@ -32,6 +32,7 @@ func Open(path string, logMode bool) error {
 		&types.Tracer{},
 		&types.TracerEvent{},
 		&types.DOMContext{},
+		&types.ReproductionTest{},
 		&types.Request{},
 		&types.RawEvent{},
 		&types.Error{})

--- a/api/types/dom_context.go
+++ b/api/types/dom_context.go
@@ -29,10 +29,11 @@ const (
 // DOMContext is an event that marks when a particular tracer was viewed again.
 type DOMContext struct {
 	gorm.Model
-	TracerEventID    uint   `json:"TracerEventID" gorm:"not null; index"`
-	EventContext     string `json:"EventContext" gorm:"not null"`
-	HTMLLocationType uint   `json:"HTMLLocationType" gorm:"not null"`
-	HTMLNodeType     string `json:"HTMLNodeType" gorm:"not null"`
-	Severity         uint   `json:"Severity" gorm:"not null"`
-	Reason           uint   `json:"Reason" gorm:"not null"`
+	TracerEventID     uint               `json:"TracerEventID" gorm:"not null; index"`
+	EventContext      string             `json:"EventContext" gorm:"not null"`
+	HTMLLocationType  uint               `json:"HTMLLocationType" gorm:"not null"`
+	HTMLNodeType      string             `json:"HTMLNodeType" gorm:"not null"`
+	Severity          uint               `json:"Severity" gorm:"not null"`
+	Reason            uint               `json:"Reason" gorm:"not null"`
+	ReproductionTests []ReproductionTest `json:"ReproductionTests"`
 }

--- a/api/types/repro.go
+++ b/api/types/repro.go
@@ -1,0 +1,22 @@
+package types
+
+import "github.com/jinzhu/gorm"
+
+// ReproductionTest is a struct that holds a single reproduction
+// test case. Reproduction tests are associated with a particular
+// event.
+type ReproductionTest struct {
+	gorm.Model
+	TracerEventID uint   `json:"TracerEventID" gorm:"not null"`
+	Exploit       string `json:"Exploit" gorm:"not null"`
+	Successful    bool   `json:"Successful" gorm:"not null"`
+}
+
+// Reproduction is the struct that holds all the information
+// a tab needs to in order to successfully reproduce a finding.
+type Reproduction struct {
+	Tracer            Tracer             `json:Tracer`
+	TracerEvent       TracerEvent        `json:TracerEvent`
+	DOMContext        DOMContext         `json:DOMContext`
+	ReproductionTests []ReproductionTest `json:ReproductionTests`
+}

--- a/api/types/websocket.go
+++ b/api/types/websocket.go
@@ -23,3 +23,9 @@ type TracerEventsWebSocket struct {
 type NotificationWebSocket struct {
 	Notification Notification `json:"Notification"`
 }
+
+// ReproductionWebSocket is a struct that is used to pass new
+// reproduction data to the extension from the UI.x
+type ReproductionWebSocket struct {
+	Reproduction Reproduction `json:Reproduction`
+}

--- a/api/view/package.json
+++ b/api/view/package.json
@@ -19,7 +19,7 @@
     "react-router": "^4.2.0",
     "react-router-bootstrap": "^0.24.4",
     "react-router-dom": "^4.2.2",
-    "react-scripts": "^1.1.1",
+    "react-scripts": "^1.1.5",
     "react-syntax-highlight": "^15.3.1",
     "react-table": "^6.8.0",
     "webpack": "^3.10.0"

--- a/api/view/src/App.jsx
+++ b/api/view/src/App.jsx
@@ -33,7 +33,7 @@ class App extends Component {
   }
 
   /* Helper  to return the URL query parameters as a comma-separated list. */
-  parseURLParameters(url) {
+  parseURLParameters = url => {
     var ret;
     var splitOnParam = url.split("?");
     if (splitOnParam.length > 1) {
@@ -43,10 +43,10 @@ class App extends Component {
     }
 
     return ret;
-  }
+  };
 
   /* Helper  to return the hostname from a URL string. */
-  parseHost(url) {
+  parseHost = url => {
     var ret;
 
     // In case the url has a protocol, remove it.
@@ -68,10 +68,10 @@ class App extends Component {
     }
 
     return ret;
-  }
+  };
 
   /* Helper  to return the path from a URL string. */
-  parsePath(url) {
+  parsePath = url => {
     var ret = "";
 
     // In case the url has a protocol, remove it.
@@ -92,7 +92,7 @@ class App extends Component {
     }
 
     return ret;
-  }
+  };
 
   // Mesage the request objects into a set of tracer data structure so the
   // table can read their columns.
@@ -100,6 +100,26 @@ class App extends Component {
     if (request.Tracers) {
       return request.Tracers.map(t => this.formatTracer(t, request));
     }
+  };
+
+  reproduce = () => {
+    if (
+      Object.keys(this.state.tracer).length === 0 ||
+      Object.keys(this.state.event).length === 0
+    ) {
+      return;
+    }
+
+    fetch(
+      this.newTracyRequest(
+        `/tracers/${this.state.tracer.ID}/events/${
+          this.state.event.ContextID
+        }/reproductions`,
+        {
+          method: "POST"
+        }
+      )
+    ).catch(err => console.error(err));
   };
 
   // formatTracer returns a new tracer object with some its fields
@@ -137,7 +157,7 @@ class App extends Component {
   };
 
   /* Format all the event contexts into their corresponding columns. */
-  formatEvent(event, eidx) {
+  formatEvent = (event, eidx) => {
     // Enum to human-readable structure to translate the various DOM contexts.
     const locationTypes = {
       0: "attribute name",
@@ -152,6 +172,7 @@ class App extends Component {
       ret = event.DOMContexts.map(
         function(context, cidx) {
           return {
+            ContextID: context.ID,
             HTMLLocationType: locationTypes[context.HTMLLocationType],
             HTMLNodeType: context.HTMLNodeType,
             EventContext: context.EventContext,
@@ -181,16 +202,16 @@ class App extends Component {
     }
 
     return ret;
-  }
+  };
 
   /* Given an event, give it an ID. */
-  enumerate(event, id) {
+  enumerate = (event, id) => {
     event.ID = id + 1;
 
     return event;
-  }
+  };
 
-  formatRowSeverity(row, rowIdx) {
+  formatRowSeverity = (row, rowIdx) => {
     // Enum to human-readable structure to translate the different severity ratings.
     const severity = {
       0: "unexploitable",
@@ -199,7 +220,7 @@ class App extends Component {
       3: "exploitable"
     };
     return severity[row.OverallSeverity];
-  }
+  };
 
   /* getProjects gets the projects available to view. */
   getProjects = () => {
@@ -293,7 +314,7 @@ class App extends Component {
   };
 
   /* Converts raw tracers into tracers that can be read by the table. */
-  parseVisibleTracers(requests = [], sfilters = {}) {
+  parseVisibleTracers = (requests = [], sfilters = {}) => {
     let ret = [];
     if (requests.length > 0) {
       const parsedTracers = [].concat
@@ -311,10 +332,10 @@ class App extends Component {
       }, parsedTracers);
     }
     return ret;
-  }
+  };
 
   /* Converts raw events into events that can be read by the table. */
-  parseVisibleEvents(events = [], sfilters = {}) {
+  parseVisibleEvents = (events = [], sfilters = {}) => {
     let ret = [];
     if (events.length > 0) {
       const parsedEvents = [].concat
@@ -339,7 +360,7 @@ class App extends Component {
       }, parsedEvents);
     }
     return ret;
-  }
+  };
 
   /* Called whenever one of the filter buttons is toggled. */
   handleFilterChange = (evt, filter) => {
@@ -395,9 +416,9 @@ class App extends Component {
     }
   };
 
-  /*handleNewTracer handles websocket messages that report new tracers. */
+  // handleNewTracer handles websocket messages that report new tracers.
   handleNewTracer = nTracer => {
-    let data = JSON.parse(nTracer.data)["Tracer"];
+    const data = JSON.parse(nTracer.data)["Tracer"];
     this.setState((prevState, props) => {
       let match = [].concat
         .apply([], prevState.tracers.map(n => n.Tracers))
@@ -420,9 +441,9 @@ class App extends Component {
     });
   };
 
-  /*handleNewRequest handles websocket messages that report new requests. */
+  // handleNewRequest handles websocket messages that report new requests.
   handleNewRequest = nRequest => {
-    let data = JSON.parse(nRequest.data)["Request"];
+    const data = JSON.parse(nRequest.data)["Request"];
     this.setState((prevState, props) => {
       let match = prevState.tracers.filter(n => n.ID === data.ID);
       if (match.length === 1) {
@@ -431,11 +452,11 @@ class App extends Component {
           if (data[n] !== match[n]) {
             match[n] = data[n];
 
-            //If the key was the RawRequest, we need to update the currently selected tracer
-            //with this value as well.
+            // If the key was the RawRequest, we need to update the currently
+            // selected tracer with this value as well.
             if (n === "RawRequest") {
-              //If the matched request has a tracer that is currently selected...
-              let selected = match.Tracers.filter(
+              // If the matched request has a tracer that is currently selected...
+              const selected = match.Tracers.filter(
                 m => m.ID === prevState.tracer.ID
               );
               if (selected.length === 1) {
@@ -457,9 +478,10 @@ class App extends Component {
     });
   };
 
-  /*handleNewEvent handles websocket messages that report a new event for the currently selected tracer. */
+  // handleNewEvent handles websocket messages that report a new event for the
+  // currently selected tracer.
   handleNewEvent = nEvent => {
-    let data = JSON.parse(nEvent.data)["TracerEvent"];
+    const data = JSON.parse(nEvent.data)["TracerEvent"];
     this.setState((prevState, props) => {
       let match = prevState.events.filter(n => n.ID === data.ID);
       if (match.length === 1) {
@@ -482,7 +504,7 @@ class App extends Component {
     });
   };
 
-  // newFindingNotification checks the browser supports notifications,
+  // handleNotification checks the browser supports notifications,
   // then either asks permission for notifications, or displays the
   // formatted notification if the user has already granted permission.
   handleNotification = (tracer, context, event) => {
@@ -543,9 +565,9 @@ HTML Parent Tag: ${context.HTMLNodeType}`;
     };
   };
 
-  /* When the app loads, make an HTTP request for the latest set of tracers and 
-   * projects. */
-  componentDidMount() {
+  // When the app loads, make an HTTP request for the latest set of tracers and
+  // projects.
+  componentDidMount = () => {
     this.getProjects();
     const proj = this.getSavedProject();
     if (proj !== null) {
@@ -554,8 +576,9 @@ HTML Parent Tag: ${context.HTMLNodeType}`;
       });
       this.switchProject(proj);
     }
-  }
+  };
 
+  // deleteProject issues an API request to delete a project from disk.
   deleteProject = proj => {
     const req = this.newTracyRequest(`/projects?proj=${proj}`, {
       method: "DELETE"
@@ -687,6 +710,7 @@ HTML Parent Tag: ${context.HTMLNodeType}`;
                 tracer={this.state.tracer}
                 loading={this.state.loading}
                 handleEventSelection={this.handleEventSelection}
+                reproduce={this.reproduce}
               />
             </Col>
           </Row>

--- a/api/view/src/TracerEventsTable.jsx
+++ b/api/view/src/TracerEventsTable.jsx
@@ -70,28 +70,42 @@ class TracerEventsTable extends Component {
               {
                 Header: "observed outputs",
                 columns: [
-                  { Header: "id", accessor: "ID", width: 30 },
+                  { Header: "id", accessor: "ID", width: 45 },
                   { Header: "host", accessor: "EventHost" },
                   { Header: "path", accessor: "EventPath" },
                   {
-                    Header: "location type",
+                    Header: "location",
                     accessor: "HTMLLocationType"
                   },
                   {
-                    Header: "node type",
+                    Header: "node",
                     accessor: "HTMLNodeType"
                   },
                   {
-                    Header: "event type",
+                    Header: "output",
                     accessor: "EventType"
                   },
                   {
                     Header: "severity",
-                    accessor: "Severity"
-                  }
+                    accessor: "Severity",
+                    width: 75
+                  } //,
+                  //                  { Header: "reproduce", width: 5 }
                 ]
               }
             ]}
+            getTdProps={(state, rowInfo, column) => {
+              return {
+                onClick: (e, handleOriginal) => {
+                  if (column.Header === "reproduce") {
+                    this.props.reproduce();
+                  }
+                  if (handleOriginal) {
+                    handleOriginal();
+                  }
+                }
+              };
+            }}
             getTrProps={(state, rowInfo, column, instance) => {
               if (rowInfo) {
                 let classname = "";

--- a/api/view/src/TracerTable.jsx
+++ b/api/view/src/TracerTable.jsx
@@ -4,104 +4,100 @@ import ReactTable from "react-table";
 import "react-table/react-table.css";
 
 class TracerTable extends Component {
-	constructor(props) {
-		super(props);
+  constructor(props) {
+    super(props);
 
-		this.onRowSelect = this.onRowSelect.bind(this);
-	}
+    this.onRowSelect = this.onRowSelect.bind(this);
+  }
 
-	onRowSelect(row) {
-		this.props.handleTracerSelection(row);
-	}
+  onRowSelect(row) {
+    this.props.handleTracerSelection(row);
+  }
 
-	shouldComponentUpdate(nextProps, nextState) {
-		let ret = false;
-		if (
-			(!this.props.tracer && nextProps.tracers) ||
-			nextProps.tracers.length !== this.props.tracers.length ||
-			nextProps.selectedTracerID !== this.props.selectedTracerID
-		) {
-			ret = true;
-		}
-		return ret;
-	}
+  shouldComponentUpdate(nextProps, nextState) {
+    let ret = false;
+    if (
+      (!this.props.tracer && nextProps.tracers) ||
+      nextProps.tracers.length !== this.props.tracers.length ||
+      nextProps.selectedTracerID !== this.props.selectedTracerID
+    ) {
+      ret = true;
+    }
+    return ret;
+  }
 
-	render() {
-		let onRowSelect = this.onRowSelect;
-		return (
-			<ReactTable
-				data={this.props.tracers}
-				columns={[
-					{
-						Header: "injection points",
-						columns: [
-							{ Header: "id", accessor: "ID", width: 30 },
-							{
-								Header: "method",
-								accessor: "RequestMethod"
-							},
-							{ Header: "host", accessor: "RequestURL" },
-							{ Header: "path", accessor: "RequestPath" },
-							{
-								Header: "tracer string",
-								accessor: "TracerString"
-							},
-							{
-								Header: "tracer payload",
-								accessor: "TracerPayload"
-							},
-							{
-								Header: "severity",
-								accessor: "OverallSeverity"
-							}
-						]
-					}
-				]}
-				getTrProps={(state, rowInfo, column, instance) => {
-					if (rowInfo) {
-						let classname = "";
-						switch (rowInfo.row.OverallSeverity) {
-							case 1:
-								classname = "suspicious";
-								break;
-							case 2:
-								classname = "probable";
-								break;
-							case 3:
-								classname = "exploitable";
-								break;
-							default:
-								classname = "unexploitable";
-						}
+  render() {
+    let onRowSelect = this.onRowSelect;
+    return (
+      <ReactTable
+        data={this.props.tracers}
+        columns={[
+          {
+            Header: "injection points",
+            columns: [
+              { Header: "id", accessor: "ID", width: 45 },
+              { Header: "method", accessor: "RequestMethod" },
+              { Header: "host", accessor: "RequestURL", width: 225 },
+              { Header: "path", accessor: "RequestPath" },
+              { Header: "tracer string", accessor: "TracerString" },
+              {
+                Header: "payload",
+                accessor: "TracerPayload",
+                width: 105
+              },
+              {
+                Header: "severity",
+                accessor: "OverallSeverity",
+                width: 75
+              }
+            ]
+          }
+        ]}
+        getTrProps={(state, rowInfo, column, instance) => {
+          if (rowInfo) {
+            let classname = "";
+            switch (rowInfo.row.OverallSeverity) {
+              case 1:
+                classname = "suspicious";
+                break;
+              case 2:
+                classname = "probable";
+                break;
+              case 3:
+                classname = "exploitable";
+                break;
+              default:
+                classname = "unexploitable";
+            }
 
-						if (rowInfo.row.ID === this.props.selectedTracerID) {
-							classname += " row-selected";
-						}
+            if (rowInfo.row.ID === this.props.selectedTracerID) {
+              classname += " row-selected";
+            }
 
-						return {
-							onClick: (e, handleOriginal) => {
-								onRowSelect(rowInfo.row);
+            return {
+              onClick: (e, handleOriginal) => {
+                onRowSelect(rowInfo.row);
 
-								if (handleOriginal) {
-									handleOriginal();
-								}
-							},
-							className: classname
-						};
-					} else {
-						return {};
-					}
-				}}
-				defaultSorted={[
-					{
-						id: "id",
-						desc: true
-					}
-				]}
-				defaultPageSize={25}
-			/>
-		);
-	}
+                if (handleOriginal) {
+                  handleOriginal();
+                }
+              },
+              className: classname
+            };
+          } else {
+            return {};
+          }
+        }}
+        defaultSorted={[
+          {
+            id: "id",
+            desc: true
+          }
+        ]}
+        defaultPageSize={25}
+      />
+    );
+  }
 }
 
 export default TracerTable;

--- a/api/view/src/WebSocketRouter.jsx
+++ b/api/view/src/WebSocketRouter.jsx
@@ -47,7 +47,6 @@ class WebSocketRouter extends Component {
 
           break;
         default:
-          console.log("WebSocket message: ", msg.data);
           break;
       }
     };
@@ -69,14 +68,13 @@ class WebSocketRouter extends Component {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    let ret = false;
     if (
       nextProps.tracer.ID !== this.props.tracer.ID ||
       nextState.isOpen !== this.state.isOpen
     ) {
-      ret = true;
+      return true;
     }
-    return ret;
+    return false;
   }
 
   render() {

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -3,7 +3,16 @@
   "description":
     "A tool designed to assist with finding all sinks and sources of a web application and display these results in a digestible manner.",
   "version": "0.3.5",
-  "permissions": ["activeTab", "<all_urls>", "storage", "contextMenus"],
+  "permissions": [
+    "activeTab",
+    "<all_urls>",
+    "storage",
+    "contextMenus",
+    "tabs",
+    "webRequest",
+    "webRequestBlocking",
+    "browsingData"
+  ],
   "background": {
     "scripts": ["scripts/background.js"],
     "persistent": true
@@ -39,6 +48,7 @@
   },
   "web_accessible_resources": [
     "scripts/innerhtml.js",
+    "scripts/repro.js",
     "scripts/method-hooking.js",
     "images/tracy_svg.svg"
   ],

--- a/plugin/scripts/background.js
+++ b/plugin/scripts/background.js
@@ -1,3 +1,120 @@
+// prepCache uses a tab to recreate the state of a page with a
+// special header attached so that tracy knows on the backend to
+// cache the responses in-memory so that we can run reproductions
+// without changing the state of the application.
+function prepCache(event) {
+  // Prep the cache by making a request through the proxy with the
+  // SET-CACHE header. Tracy will keep these responses in memory for
+  // the rest of our reproduction steps.
+  chrome.tabs.create({ active: false }, tab => {
+    const beforeHandler = details => {
+      return {
+        requestHeaders: details.requestHeaders.concat({
+          name: "X-TRACY",
+          value: "SET-CACHE"
+        })
+      };
+    };
+
+    // Requests that come from this tab ID should be proxied
+    // and have the special header `SET-CACHE` added to it.
+    chrome.webRequest.onBeforeSendHeaders.addListener(
+      beforeHandler,
+      { urls: ["<all_urls>"], tabId: tab.id },
+      ["blocking", "requestHeaders"]
+    );
+
+    // After the page is finished loading, close the tab.
+    chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+      if (tabId === tab.id && changeInfo.status === "complete") {
+        removeTab(tab.id);
+      }
+    });
+
+    // Store the tab so that we can prevent the MutationObserver from triggering
+    // during the reproduction steps flows.
+    memoTabs.add(tab.id, {
+      event: event
+    });
+
+    // Clear the browser cache before we prep so that we don't
+    // get in a weird situation where we open a tab and some resources
+    // were cached by the browser, but when we go to reproduce
+    // they aren't in our cache.
+    chrome.browsingData.removeCache({});
+
+    // Change the URL of the blank page after all the callbacks are properly
+    // set up so that we can capture all the requests.
+    chrome.tabs.update(tab.id, { url: event.EventURL });
+  });
+}
+
+// reproduceFinding takes a tracer and event and attempts to reproduce
+// the finding with a valid XSS payload. If done successfully, this
+// background page should be able to inject a script to read a predictable
+// value from the page. Reproduction are completed using the
+// in-memory cache of responses from this event.
+function reproduceFinding(tracer, event, context, repros) {
+  // For each of the reproduction steps, spin up a tab to
+  // test the different exploits.
+  repros.map(repro => {
+    // After the cache has been prepped, send the exploits.
+    chrome.tabs.create({ active: false }, tab => {
+      const callback = details => {
+        return {
+          requestHeaders: details.requestHeaders.concat({
+            name: "X-TRACY",
+            value:
+              "GET-CACHE;" + btoa(repro.Exploit + "--" + tracer.TracerPayload)
+          })
+        };
+      };
+
+      // Requests that come from this tab ID should be proxied
+      // and have the special header `GET-CACHE` added to it,
+      // along with the data the extension wants to have swapped out
+      // on the server.
+      chrome.webRequest.onBeforeSendHeaders.addListener(
+        callback,
+        { urls: ["<all_urls>"], tabId: tab.id },
+        ["blocking", "requestHeaders"]
+      );
+
+      // After the page is finished loading, close the tab.
+      chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+        if (tabId === tab.id && changeInfo.status === "complete") {
+          // We can probably remove this timeout once we learn more about
+          // the average time it takes to fire a payload after the page has
+          // completed.
+          removeTab(tab.id);
+        }
+      });
+
+      memoTabs.add(tab.id, {
+        tracer: tracer,
+        event: event,
+        context: context,
+        repro: repro,
+        callback: callback
+      });
+
+      chrome.tabs.update(tab.id, { url: event.EventURL });
+    });
+  });
+}
+
+// tabs keeps a running tally of the currently tested tabs
+// that are being opened and closed for reproduction steps.
+function tabs() {
+  let tabs = {};
+  return {
+    get: () => tabs,
+    add: (t, args) => (tabs[`${t}`] = args),
+    del: t => delete tabs[`${t}`]
+  };
+}
+const memoTabs = tabs();
+
 // bulkAddEvents makes a POST request to the bulk events to the API with
 // a set of events from the DOM.
 function bulkAddEvents(events) {
@@ -61,7 +178,7 @@ function requestHandler(domEvents) {
           RawEvent: {
             Data: domEvent.msg
           },
-          EventURL: encodeURI(domEvent.location),
+          EventURL: domEvent.location,
           EventType: domEvent.type
         },
         TracerPayloads: tracersPerDomEvent
@@ -77,7 +194,7 @@ function requestHandler(domEvents) {
 
 // Routes messages from the extension to various functions on the background.
 function messageRouter(message, sender, sendResponse) {
-  if (message && message["message-type"]) {
+  if (message["message-type"]) {
     switch (message["message-type"]) {
       case "job":
         addJobToQueue(message, sender, sendResponse);
@@ -89,13 +206,62 @@ function messageRouter(message, sender, sendResponse) {
         refreshConfig(false);
         break;
     }
+  } else if (message.r) {
+    // Changed the format of the message so we
+    // wouldn't have such a long XSS payload.
+    updateReproduction(message, sender);
   }
+}
+
+// updateReproduction validates that a particular tab
+// executed a Javascript payload correctly.
+function updateReproduction(message, sender) {
+  const tab = memoTabs.get()[sender.tab.id];
+  if (!tab) {
+    return;
+  }
+  const reproTest = { Successful: true };
+
+  fetch(
+    `http://${restServer}/tracers/${tab.tracer.ID}/events/${
+      tab.context.ID
+    }/reproductions/${tab.repro.ID}`,
+    {
+      method: "PUT",
+      body: JSON.stringify(reproTest),
+      headers: { Hoot: "!" }
+    }
+  ).catch(err => console.error(err));
+
+  removeTab(sender.tab.id);
+}
+
+// removeTab removes the tab from the browser and also removes the
+// tab from list of currently available tabs that are cached.
+function removeTab(id) {
+  // Close the tab when we are done with it.
+  chrome.tabs.remove(id);
+  // Remove the tab from the list of collected tabs.
+  memoTabs.del(id);
 }
 
 // refresheConfig makes an API request for the latest config from `/config`,
 // pulls configuration from the extension settings page and gets a current
 // list of tracers. refreshConfig is usually called on page load.
 async function refreshConfig(wsConnect) {
+  const ok = await new Promise(resolve =>
+    chrome.tabs.query({ active: true }, tab => {
+      // Don't refresh config if we are in the reproduction steps flow.
+      if (memoTabs.get()[tab.id]) {
+        resolve(false);
+      } else {
+        resolve(true);
+      }
+    })
+  );
+  if (!ok) {
+    return;
+  }
   const settings = await new Promise(resolve =>
     chrome.storage.local.get({ restHost: "localhost", restPort: 8081 }, res =>
       resolve(res)
@@ -152,7 +318,7 @@ async function refreshConfig(wsConnect) {
 // Connect to the websocket endpoint so we don't have to poll for new tracer strings.
 function websocketConnect() {
   const nws = new WebSocket(`ws://${restServer}/ws`);
-  nws.addEventListener("message", function(event) {
+  nws.addEventListener("message", event => {
     let req = JSON.parse(event.data);
     switch (Object.keys(req)[0]) {
       case "Request":
@@ -162,15 +328,31 @@ function websocketConnect() {
           }
         });
         break;
+      case "Reproduction":
+        reproduceFinding(
+          req.Reproduction.Tracer,
+          req.Reproduction.TracerEvent,
+          req.Reproduction.DOMContext,
+          req.Reproduction.ReproductionTests
+        );
+        break;
+      case "Notification":
+        const n = req.Notification;
+        n.Event.DOMContexts.map(c => {
+          if (c.Severity >= 2) {
+            prepCache(n.Event);
+            return true;
+          }
+          return false;
+        });
+        break;
       default:
         break;
     }
   });
 
-  nws.addEventListener("close", function() {
-    // Attempt to reconnect when the socket closes.
-    setTimeout(websocketConnect, 1500);
-  });
+  // Attempt to reconnect when the socket closes.
+  nws.addEventListener("close", () => setTimeout(websocketConnect, 1500));
 }
 
 // configQuery returns the appropriate configuration information
@@ -193,6 +375,11 @@ function configQuery(message, sender, sendResponse) {
 
 // Add a job to the job queue.
 function addJobToQueue(message, sender, sendResponse) {
+  // Don't add a job if it's one of the tabs that we have collected
+  // in our reproduction steps flow.
+  if (memoTabs.get()[sender.tab.id]) {
+    return;
+  }
   // If it is the first job added, set a timer to process the jobs.
   if (jobs.length === 0) {
     setTimeout(processDomEvents, 2000);

--- a/plugin/scripts/dom-mutations.js
+++ b/plugin/scripts/dom-mutations.js
@@ -2,14 +2,14 @@ chrome.runtime.sendMessage({
   "message-type": "refresh"
 });
 
-/* This observer will be used to observe changes in the DOM. It will batches DOM changes and send them to the API
- * server if it finds a tracer string. */
-var observer = new MutationObserver(function(mutations) {
-  var parentNode = null;
+// This observer will be used to observe changes in the DOM. It will batches DOM changes and send them to the API
+// server if it finds a tracer string.
+const observer = new MutationObserver(mutations => {
+  let parentNode = null;
 
-  mutations.forEach(function(mutation) {
+  mutations.forEach(mutation => {
     if (mutation.addedNodes.length > 0) {
-      mutation.addedNodes.forEach(function(node) {
+      mutation.addedNodes.forEach(node => {
         /* Check to see if a node is a child of the parentNode if so don't add it because we already have that data */
         if (parentNode === null || !parentNode.contains(node)) {
           /* The only supported DOM types that we care about are `DOM` (1) and `text` (3). */
@@ -54,8 +54,8 @@ var observer = new MutationObserver(function(mutations) {
   }, this);
 });
 
-/* The configuration for the observer. We want to pretty much watch for everything. */
-var observerConfig = {
+// The configuration for the observer. We want to pretty much watch for everything.
+const observerConfig = {
   attributes: true,
   childList: true,
   characterData: true,

--- a/plugin/scripts/method-hooking-injector.js
+++ b/plugin/scripts/method-hooking-injector.js
@@ -7,21 +7,16 @@
 
   // A list of scripts we want to inject into the page rather than have them as a
   // content script.
-  const injectionScripts = ["innerhtml.js"];
+  const injectionScripts = ["innerhtml.js", "repro.js"];
   // Inject the scripts.
-  injectionScripts.map(getInjectionSrc).map(injectScript);
+  injectionScripts.map(injectScript);
 
-  /*getInjectionSrc returns the file path of the script we are trying to inject */
-  function getInjectionSrc(file) {
-    return chrome.runtime.getURL(`scripts/${file}`);
-  }
-
-  /*injectScript injects the script into the page and then removes it. */
-  function injectScript(src) {
+  // injectScript injects the script into the page and then removes it.
+  function injectScript(file) {
     const hookInjector = document.createElement("script");
     hookInjector.type = "text/javascript";
-    hookInjector.src = src;
+    hookInjector.src = chrome.runtime.getURL(`scripts/${file}`);
     document.documentElement.appendChild(hookInjector);
-    hookInjector.parentNode.removeChild(hookInjector); // TODO: do we need to remove it?
+    hookInjector.parentNode.removeChild(hookInjector);
   }
 })();

--- a/plugin/scripts/repro.js
+++ b/plugin/scripts/repro.js
@@ -1,0 +1,6 @@
+(function() {
+  const elems = document.querySelectorAll("[onfocus]");
+  for (let i = 0; i < elems.length; i++) {
+    elems[i].onfocus();
+  }
+})();

--- a/plugin/scripts/tabs.js
+++ b/plugin/scripts/tabs.js
@@ -1,0 +1,14 @@
+var i = 1000;
+var promises = [];
+for (var j = 0; j < i; j++) {
+  promises.push(chrome.tabs.create({ url: "https://example.com" }));
+}
+
+for (var j = 0; j < i; j++) {
+  setTimeout(
+    promises[i].then(tab => {
+      chrome.tabs.discard(tab.id);
+    }),
+    Math.random() * 1000
+  );
+}

--- a/proxy/cache.go
+++ b/proxy/cache.go
@@ -1,0 +1,44 @@
+package proxy
+
+var requestCacheSetChan chan *requestCacheSet
+var requestCacheGetChan chan *requestCacheGet
+
+type requestCacheSet struct {
+	url    string
+	method string
+	resp   []byte
+}
+
+type requestCacheGet struct {
+	url    string
+	method string
+	ok     chan bool
+	resp   chan []byte
+}
+
+func init() {
+	requestCacheSetChan = make(chan *requestCacheSet, 50)
+	requestCacheGetChan = make(chan *requestCacheGet, 50)
+	go requestCacheRunner()
+}
+
+func requestCacheRunner() {
+	var (
+		set  *requestCacheSet
+		get  *requestCacheGet
+		resp []byte
+		ok   bool
+	)
+	cache := make(map[string][]byte)
+	for {
+		select {
+		case set = <-requestCacheSetChan:
+			// Caching takes into account the request method as well as the URL.
+			cache[set.method+":"+set.url] = set.resp
+		case get = <-requestCacheGetChan:
+			resp, ok = cache[get.method+":"+get.url]
+			get.ok <- ok
+			get.resp <- resp
+		}
+	}
+}


### PR DESCRIPTION
findings. Currently, there is no UI or method for invoking this
feature because it will likely take a lot more time to get the updated
UI working and will probably justify more UI changes. When a sev level
3 or 2 is discovered, the plugin automatically spins up a tab to open
the page the event occured on and caches all responses from the page
load. These responses are stored in an in-memory cache and are used to
perform reproduction steps without changing the state of the
application. It allows frontend fuzzing with multiple tabs in parallel
that don't change the state of the app. Ideally, the use will click
some button that will allow them to initate the reproductions.

starting new branch for reproduction steps

Signed-off-by: Jacob Ryan Heath <jake.heath@nccgroup.trust>

First step to autoreproduction steps finished. Base cases seem to
work, reflected XSS still needs to be worked on though.

Got the cache to properly store request responses and have removed all
cache headers so we don't accidently store 304 responses. Last thing
to hook up is the auto-prep on red and orange flags and the payload
swapping. This commit also fixed issues with gziping and transfer
encoding chunked. We don't store compressed or chunked data so it is
easier to swap.

Caching automatically triggers when red and orange event
occur. Caching on the server seems to work well, although the proxy
seems slow now. PNGs taking ~15 seconds to load. Might be updates to
VMware network though. Also, getting lots of DNS issues

Reproduction is ready! Just needs a UI. Added a new permission that
clears that browser cache before prepping the proxy cache so that we
properly catch all assets, changed the base64 formatting so that it
doesn't break for JS objects, and alsomake a need payload that is
executed inline rather than via an injected function due to the very
difficult timing issues with when a script was injected and when it
needed to be checked.

moving some columns around, removing old debugging logs, and making sure the tab closes as soon as the page is finished loading for cached requests

Signed-off-by: Jacob Ryan Heath <jake.heath@nccgroup.trust>