### PR TITLE
yep

### DIFF
--- a/api/api-standalone/main.go
+++ b/api/api-standalone/main.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	_ "net/http/pprof"
 	"os"
-	"os/exec"
 	"os/signal"
-	"runtime"
 	"runtime/pprof"
 
 	"github.com/nccgroup/tracy/api/rest"
@@ -29,10 +27,6 @@ func main() {
 
 	fmt.Printf("Tracer server:\t%s%s",
 		configure.Current.TracyServer.Addr(), log.NewLine)
-
-	if configure.Current.AutoLaunch {
-		processAutoLaunch()
-	}
 
 	// Wait for the user to close the program.
 	signalChan := make(chan os.Signal, 1)
@@ -75,30 +69,4 @@ func init() {
 	// Initialize the HTTP routes.
 	rest.Configure(rest.API_ONLY)
 
-}
-
-// processAutoLaunch launchs whatever browser they have configured.
-func processAutoLaunch() {
-	openbrowser(fmt.Sprintf("%s", configure.Current.TracyServer.Addr()))
-}
-
-// openBrowser opens the default browser the user has configured.
-// Taken from here https://gist.github.com/hyg/9c4afcd91fe24316cbf0
-func openbrowser(url string) {
-	var err error
-
-	switch runtime.GOOS {
-	case "linux":
-		err = exec.Command("xdg-open", url).Start()
-	case "windows":
-		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
-	case "darwin":
-		err = exec.Command("open", url).Start()
-	default:
-		err = fmt.Errorf("unsupported platform")
-	}
-
-	if err != nil {
-		log.Error.Print(err)
-	}
 }

--- a/api/common/tracer.go
+++ b/api/common/tracer.go
@@ -70,6 +70,27 @@ func AddTracer(request types.Request) ([]byte, error) {
 	return ret, err
 }
 
+// updateTracer is the common functionality to add a tracer to the database.
+func UpdateTracer(request types.Request) ([]byte, error) {
+	var (
+		ret []byte
+		err error
+	)
+
+	if err = store.DB.Save(&request).Error; err != nil {
+		log.Warning.Printf(err.Error())
+		return ret, err
+	}
+
+	inUpdateChanTracer <- request
+	UpdateSubscribers(request)
+	if ret, err = json.Marshal(request); err != nil {
+		log.Warning.Printf(err.Error())
+	}
+
+	return ret, err
+}
+
 // GetTracer is the common functionality to get a tracer from the database by it's ID.
 func GetTracer(tracerID uint) ([]byte, error) {
 	var (

--- a/api/common/tracer.go
+++ b/api/common/tracer.go
@@ -71,7 +71,7 @@ func AddTracer(request types.Request) ([]byte, error) {
 }
 
 // updateTracer is the common functionality to add a tracer to the database.
-func UpdateTracer(request types.Request) ([]byte, error) {
+func UpdateRequest(request types.Request) ([]byte, error) {
 	var (
 		ret []byte
 		err error

--- a/api/rest/init.go
+++ b/api/rest/init.go
@@ -31,7 +31,7 @@ var (
 		handler func(http.ResponseWriter, *http.Request)
 	}{
 		{http.MethodPost, "/tracers", AddTracers},
-		{http.MethodPatch, "/tracers", updateTracer},
+		{http.MethodPatch, "/tracers/request", updateRequest},
 		{http.MethodGet, "/tracers/generate", GenerateTracer},
 		{http.MethodGet, "/tracers/{tracerID}/request", GetRequest},
 		{http.MethodGet, "/tracers/{tracerID}", GetTracer},

--- a/api/rest/init.go
+++ b/api/rest/init.go
@@ -31,6 +31,7 @@ var (
 		handler func(http.ResponseWriter, *http.Request)
 	}{
 		{http.MethodPost, "/tracers", AddTracers},
+		{http.MethodPatch, "/tracers", updateTracer},
 		{http.MethodGet, "/tracers/generate", GenerateTracer},
 		{http.MethodGet, "/tracers/{tracerID}/request", GetRequest},
 		{http.MethodGet, "/tracers/{tracerID}", GetTracer},
@@ -56,108 +57,122 @@ var (
 	}
 )
 
+//Jake said he loves enums so we will give him enums
+const (
+	PROXY_ONLY = iota
+	FULL
+	API_ONLY
+)
+
 // Configure configures all the HTTP routes and assigns them handler functions.
-func Configure() {
+func Configure(mode int) {
 	Router = mux.NewRouter()
-	api := Router.PathPrefix("/api/tracy").Subrouter()
+	if mode >= FULL { //make this over complicated so Jake hates me
 
-	for _, row := range apiTable {
-		api.
-			Path(row.path).
-			Methods(row.method, http.MethodOptions).
-			HandlerFunc(row.handler).
-			Name(fmt.Sprintf("%s:%s", row.method, row.path))
-	}
-	for _, m := range apiMw {
-		api.Use(m)
-	}
+		api := Router.PathPrefix("/api/tracy").Subrouter()
 
-	wui := Router.NewRoute().Name("webUI").BuildOnly()
-	Router.MatcherFunc(func(req *http.Request, m *mux.RouteMatch) bool {
-		// If the host header indicates the request is going straight to
-		// the app, consider it going to the UI, direct them to it.
-		if req.Method == http.MethodGet && strings.HasSuffix(req.Host, fmt.Sprintf("%d", configure.Current.TracyServer.Port)) &&
-			(req.URL.Path == "/" || req.URL.Path == "" || strings.HasPrefix(req.URL.Path, "/static") || strings.HasPrefix(req.URL.Path, "/tracy.ico")) {
-			m.Route = wui
-			if v := flag.Lookup("test.v"); v != nil || configure.Current.DebugUI {
-				m.Handler = http.FileServer(http.Dir("./api/view/build"))
-			} else {
-				m.Handler = http.FileServer(assetFS())
+		for _, row := range apiTable {
+			api.
+				Path(row.path).
+				Methods(row.method, http.MethodOptions).
+				HandlerFunc(row.handler).
+				Name(fmt.Sprintf("%s:%s", row.method, row.path))
+		}
+		for _, m := range apiMw {
+			api.Use(m)
+		}
+
+		wui := Router.NewRoute().Name("webUI").BuildOnly()
+		Router.MatcherFunc(func(req *http.Request, m *mux.RouteMatch) bool {
+			// If the host header indicates the request is going straight to
+			// the app, consider it going to the UI, direct them to it.
+			if req.Method == http.MethodGet && strings.HasSuffix(req.Host, fmt.Sprintf("%d", configure.Current.TracyServer.Port)) &&
+				(req.URL.Path == "/" || req.URL.Path == "" || strings.HasPrefix(req.URL.Path, "/static") || strings.HasPrefix(req.URL.Path, "/tracy.ico")) {
+				m.Route = wui
+				if v := flag.Lookup("test.v"); v != nil || configure.Current.DebugUI {
+					m.Handler = http.FileServer(http.Dir("./api/view/build"))
+				} else {
+					m.Handler = http.FileServer(assetFS())
+				}
+				m.MatchErr = nil
+				return true
 			}
-			m.MatchErr = nil
-			return true
+			return false
+		})
+
+		ws := Router.NewRoute().Name("websocket").BuildOnly()
+		Router.MatcherFunc(func(req *http.Request, m *mux.RouteMatch) bool {
+			// If the host header indicates the request is going straight to
+			// the app, consider it going to the UI, direct them to it.
+			if req.Method == http.MethodGet && req.URL.Path == "/ws" && strings.HasSuffix(req.Host, fmt.Sprintf("%d", configure.Current.TracyServer.Port)) {
+				m.Route = ws
+				m.Handler = http.HandlerFunc(WebSocket)
+				m.MatchErr = nil
+
+				return true
+			}
+
+			return false
+		})
+
+		var h http.Handler
+		if v := flag.Lookup("test.v"); v != nil || configure.Current.DebugUI {
+			h = http.FileServer(http.Dir("./api/view/build"))
+		} else {
+			h = http.FileServer(assetFS())
 		}
-		return false
-	})
 
-	ws := Router.NewRoute().Name("websocket").BuildOnly()
-	Router.MatcherFunc(func(req *http.Request, m *mux.RouteMatch) bool {
-		// If the host header indicates the request is going straight to
-		// the app, consider it going to the UI, direct them to it.
-		if req.Method == http.MethodGet && req.URL.Path == "/ws" && strings.HasSuffix(req.Host, fmt.Sprintf("%d", configure.Current.TracyServer.Port)) {
-			m.Route = ws
-			m.Handler = http.HandlerFunc(WebSocket)
-			m.MatchErr = nil
+		thost := Router.NewRoute().Name("tracyHost").BuildOnly()
+		Router.MatcherFunc(func(req *http.Request, m *mux.RouteMatch) bool {
+			if strings.HasPrefix(req.Host, "tracy") {
+				m.Route = thost
+				m.Handler = h
+				m.MatchErr = nil
+				return true
+			}
+			return false
+		})
 
-			return true
-		}
-
-		return false
-	})
-
-	var h http.Handler
-	if v := flag.Lookup("test.v"); v != nil || configure.Current.DebugUI {
-		h = http.FileServer(http.Dir("./api/view/build"))
-	} else {
-		h = http.FileServer(assetFS())
 	}
 
-	// Catch everything else.
-	t, u, d, bp, bufp := configure.ProxyServer()
-	p := proxy.New(t, u, d, bp, bufp)
+	if mode <= FULL {
 
-	thost := Router.NewRoute().Name("tracyHost").BuildOnly()
-	Router.MatcherFunc(func(req *http.Request, m *mux.RouteMatch) bool {
-		if strings.HasPrefix(req.Host, "tracy") {
-			m.Route = thost
-			m.Handler = h
+		// Catch everything else.
+		t, u, d, bp, bufp := configure.ProxyServer()
+		p := proxy.New(t, u, d, bp, bufp)
+
+		// For CONNECT requests, the path will be an absolute URL
+		Router.SkipClean(true)
+
+		// Proxy catches everything, except for requests back to itself.
+		prox := Router.NewRoute().Name("proxy").BuildOnly()
+		Router.MatcherFunc(func(req *http.Request, m *mux.RouteMatch) bool {
+			server, err := configure.ParseServer(req.Host)
+			if err != nil {
+				log.Error.Print(err)
+				return false
+			}
+			//SANITY CHECK: if we are about to send a request back to the proxy,
+			// we hit a recursion and something is up.
+			if req.Method != http.MethodConnect && server.Equal(configure.Current.TracyServer) && mode != PROXY_ONLY {
+				return false
+			}
+
+			m.Route = prox
+			m.Handler = p
 			m.MatchErr = nil
 			return true
-		}
-		return false
-	})
+		})
 
-	// For CONNECT requests, the path will be an absolute URL
-	Router.SkipClean(true)
-
-	// Proxy catches everything, except for requests back to itself.
-	prox := Router.NewRoute().Name("proxy").BuildOnly()
-	Router.MatcherFunc(func(req *http.Request, m *mux.RouteMatch) bool {
-		server, err := configure.ParseServer(req.Host)
-		if err != nil {
-			log.Error.Print(err)
-			return false
-		}
-		//SANITY CHECK: if we are about to send a request back to the proxy,
-		// we hit a recursion and something is up.
-		if req.Method != http.MethodConnect && server.Equal(configure.Current.TracyServer) {
-			return false
-		}
-
-		m.Route = prox
-		m.Handler = p
-		m.MatchErr = nil
-		return true
-	})
-
-	// This is the catch all route. Specifically, it should catch recursion
-	// requests and return a 404 instead.
-	Router.MatcherFunc(func(req *http.Request, m *mux.RouteMatch) bool {
-		m.Route = nil
-		m.Handler = http.NotFoundHandler()
-		m.MatchErr = nil
-		return true
-	})
+		// This is the catch all route. Specifically, it should catch recursion
+		// requests and return a 404 instead.
+		Router.MatcherFunc(func(req *http.Request, m *mux.RouteMatch) bool {
+			m.Route = nil
+			m.Handler = http.NotFoundHandler()
+			m.MatchErr = nil
+			return true
+		})
+	}
 
 	Server = &http.Server{
 		Handler: Router,

--- a/api/rest/tracer.go
+++ b/api/rest/tracer.go
@@ -31,6 +31,26 @@ func AddTracers(w http.ResponseWriter, r *http.Request) {
 	w.Write(ret)
 }
 
+// AddTracers handles the HTTP API request to add a set of tracers from a Request
+// to the database.
+func updateTracer(w http.ResponseWriter, r *http.Request) {
+	fmt.Println("HTITHTITHTIHTI")
+	var in types.Request
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		returnError(w, err)
+		return
+	}
+
+	ret, err := common.UpdateTracer(in)
+	if err != nil {
+		returnError(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(ret)
+}
+
 // GetTracers handles the HTTP API request for getting all the tracers from the
 // database.
 func GetTracers(w http.ResponseWriter, r *http.Request) {

--- a/api/rest/tracer.go
+++ b/api/rest/tracer.go
@@ -34,7 +34,7 @@ func AddTracers(w http.ResponseWriter, r *http.Request) {
 // AddTracers handles the HTTP API request to add a set of tracers from a Request
 // to the database.
 func updateTracer(w http.ResponseWriter, r *http.Request) {
-	fmt.Println("HTITHTITHTIHTI")
+
 	var in types.Request
 	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
 		returnError(w, err)

--- a/api/rest/tracer.go
+++ b/api/rest/tracer.go
@@ -33,7 +33,7 @@ func AddTracers(w http.ResponseWriter, r *http.Request) {
 
 // AddTracers handles the HTTP API request to add a set of tracers from a Request
 // to the database.
-func updateTracer(w http.ResponseWriter, r *http.Request) {
+func updateRequest(w http.ResponseWriter, r *http.Request) {
 
 	var in types.Request
 	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
@@ -41,7 +41,7 @@ func updateTracer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ret, err := common.UpdateTracer(in)
+	ret, err := common.UpdateRequest(in)
 	if err != nil {
 		returnError(w, err)
 		return

--- a/proxy/proxy-standalone/main.go
+++ b/proxy/proxy-standalone/main.go
@@ -72,13 +72,21 @@ func init() {
 		pprof.StartCPUProfile(f)
 	}
 
-	// Open the database.
-	if err := store.Open(configure.Current.DatabasePath, log.Verbose); err != nil {
-		log.Error.Fatal(err.Error())
-	}
+	// // Open the database.
+	// if err := store.Open(configure.Current.DatabasePath, log.Verbose); err != nil {
+	// 	log.Error.Fatal(err.Error())
+	// }
 
 	// Initialize the HTTP routes.
-	rest.Configure(rest.FULL)
+
+	oldHost := configure.Current.TracyServer.Hostname
+	oldPort := configure.Current.TracyServer.Port
+
+	configure.Current.TracyServer.Hostname = "127.0.0.1" //This is a hack to fix the fact we don't have an option to config just the proxy. Need to talk to Jake about how to fix this for real
+	configure.Current.TracyServer.Port = 8888
+	rest.Configure(rest.PROXY_ONLY)
+	configure.Current.TracyServer.Hostname = oldHost
+	configure.Current.TracyServer.Port = oldPort
 
 	// Instantiate the certificate cache.
 	certsJSON, err := ioutil.ReadFile(configure.Current.CertCachePath)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -87,7 +87,7 @@ func (p *Proxy) identifyRequestsforGeneratedTracer(d []byte, method string) {
 
 			jsonData, _ := json.Marshal(req)
 
-			_, err = p.apiRequest(http.MethodPatch, jsonData, "/api/tracy/tracers")
+			_, err = p.apiRequest(http.MethodPatch, jsonData, "/api/tracy/tracers/request")
 
 			if err != nil {
 				log.Error.Print(err)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -101,6 +101,21 @@ func (p *Proxy) identifyRequestsforGeneratedTracer(d []byte, method string) {
 	}
 }
 
+func (p *Proxy) apiRequest(method string, data []byte, endpoint string) (*http.Response, error) {
+	req, err := http.NewRequest(method, "http://"+configure.Current.TracyServer.Addr()+endpoint, bytes.NewBuffer(data))
+	if err != nil {
+		log.Error.Print(err)
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Hoot", "Hoot")
+
+	response, err := p.APIClient.Do(req)
+
+	return response, err
+}
+
 // findTracers finds tracer strings in a string.
 func (p *Proxy) findTracers(s string, requests []types.Request) ([]types.Tracer, error) {
 	// For each of the tracers, look for the tracer's tracer string.

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -87,7 +87,7 @@ func (p *Proxy) identifyRequestsforGeneratedTracer(d []byte, method string) {
 
 			jsonData, _ := json.Marshal(req)
 
-			_, err = p.apiRequest(http.MethodPatch, jsonData, "/api/tracy/tracers")
+			_, err = p.apiRequest(http.MethodPatch\, jsonData, "/api/tracy/tracers")
 
 			if err != nil {
 				log.Error.Print(err)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -365,14 +365,9 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 				Tracers:       tracers,
 			}
 
-			//_, err = common.AddTracer(r)
 			jsonData, _ := json.Marshal(r)
 
-			req, err := http.NewRequest("POST", "http://"+configure.Current.TracyServer.Addr()+"/api/tracy/tracers", bytes.NewBuffer(jsonData)) //Change this over to https when we do that. Well it would be better to make it a config
-			req.Header.Set("Content-Type", "application/json")
-			req.Header.Set("Hoot", "Hoot")
-
-			_, err = p.APIClient.Do(req)
+			_, err = p.apiRequest(http.MethodPost, jsonData, "/api/tracy/tracers")
 
 			if err != nil {
 				log.Error.Print(err)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -87,7 +87,7 @@ func (p *Proxy) identifyRequestsforGeneratedTracer(d []byte, method string) {
 
 			jsonData, _ := json.Marshal(req)
 
-			_, err = p.apiRequest("PATCH", jsonData, "/api/tracy/tracers")
+			_, err = p.apiRequest(http.MethodPatch, jsonData, "/api/tracy/tracers")
 
 			if err != nil {
 				log.Error.Print(err)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -40,15 +40,13 @@ type Proxy struct {
 func New(transport http.Transport, upgrader websocket.Upgrader,
 	dialer websocket.Dialer, bp, bufp *sync.Pool) *Proxy {
 
-	client := &http.Client{}
-
 	return &Proxy{
 		HTTPTransport:     transport,
 		HTTPBufferPool:    bufp,
 		HTTPBytePool:      bp,
 		WebSocketUpgrader: upgrader,
 		WebSocketDialer:   dialer,
-		APIClient:         client,
+		APIClient:         &http.Client{},
 	}
 }
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -87,11 +87,7 @@ func (p *Proxy) identifyRequestsforGeneratedTracer(d []byte, method string) {
 
 			jsonData, _ := json.Marshal(req)
 
-			req, err := http.NewRequest("PATCH", "http://"+configure.Current.TracyServer.Addr()+"/api/tracy/tracers", bytes.NewBuffer(jsonData)) //Change this over to https when we do that. Well it would be better to make it a config
-			req.Header.Set("Content-Type", "application/json")
-			req.Header.Set("Hoot", "Hoot")
-
-			_, err = p.APIClient.Do(req)
+			_, err = p.apiRequest("PATCH", jsonData, "/api/tracy/tracers")
 
 			if err != nil {
 				log.Error.Print(err)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -87,7 +87,7 @@ func (p *Proxy) identifyRequestsforGeneratedTracer(d []byte, method string) {
 
 			jsonData, _ := json.Marshal(req)
 
-			_, err = p.apiRequest(http.MethodPatch\, jsonData, "/api/tracy/tracers")
+			_, err = p.apiRequest(http.MethodPatch, jsonData, "/api/tracy/tracers")
 
 			if err != nil {
 				log.Error.Print(err)


### PR DESCRIPTION
added the ability to split the API and the proxy. Still needs some work but it's functional. At least as far as I know.

Removed the ability to track tracers via the response
Made Proxy use the API
Hacked in a fix for not having a config option for proxy.. For now.

Notes:

- The API to deal with adding request on gen payload might cause some slowdowns as it makes a lot of request.
- There is no way to config the proxy right now to include secure request. This should be added later
- Came up with a cleaver, or silly, hack to deal with the proxy and API being the same thing. Enums are cool! 