### PR TITLE
Don't white out row color when selected

### DIFF
--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -269,18 +269,18 @@ pre.raw-data {
   color: #e6e6e8;
 }
 
-.exploitable {
+.exploitable, .row-selected.exploitable {
   color: #ff9994;
 }
 
 .unexploitable {
 }
 
-.suspicious {
+.suspicious, .row-selected.suspicious {
   color: #fdfd96;
 }
 
-.probable {
+.probable, .row-selected.probable {
   color: #ffb347;
 }
 


### PR DESCRIPTION
Currently, when a row is selected, in either of the left side boxes, the color of the text turns white.  This can lead to a user not realizing there is xss possibilities if they come back to tracy and the selected row has changed to red (or any other color) but they would not know because it would still appear white.